### PR TITLE
feat: support soft sentinel failovers

### DIFF
--- a/cmd/bench/bench.go
+++ b/cmd/bench/bench.go
@@ -42,7 +42,7 @@ func main() {
 
 	start := make(chan struct{})
 	go serveBenchRemote(benchListener, start)
-	go redplex.NewServer(redplexListener, redplex.NewPubsub(dialer, time.Second)).Listen()
+	go redplex.NewServer(redplexListener, redplex.NewPubsub(redplex.NewDirectDialer(remoteAddress, 0), time.Second)).Listen()
 
 	f, _ := os.Create("cpu.profile")
 	pprof.StartCPUProfile(f)
@@ -124,5 +124,3 @@ func serveBenchRemote(l net.Listener, start <-chan struct{}) {
 		cnx.Write(toWrite)
 	}
 }
-
-func dialer() (net.Conn, error) { return net.Dial("tcp", remoteAddress) }

--- a/cmd/redplex/redplex.go
+++ b/cmd/redplex/redplex.go
@@ -8,8 +8,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/FZambia/go-sentinel"
-	"github.com/garyburd/redigo/redis"
 	"github.com/mixer/redplex"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -20,6 +18,7 @@ var (
 	address        = kingpin.Flag("listen", "Address to listen on").Short('l').Default("127.0.0.1:3000").String()
 	network        = kingpin.Flag("network", "Network to listen on").Short('n').Default("tcp").String()
 	remote         = kingpin.Flag("remote", "Remote address of the Redis server").Default("127.0.0.1:6379").String()
+	remoteNetwork  = kingpin.Flag("remote-network", "Remote network to dial through (usually tcp or tcp6)").Default("tcp").String()
 	sentinels      = kingpin.Flag("sentinels", "A list of Redis sentinel addresses").Strings()
 	sentinelMaster = kingpin.Flag("sentinel-name", "The name of the sentinel master").String()
 	logLevel       = kingpin.Flag("log-level", "Log level (one of debug, info, warn, error").Default("info").String()
@@ -46,9 +45,9 @@ func main() {
 
 	var dialer redplex.Dialer
 	if *sentinelMaster != "" {
-		dialer = dialSentinel
+		dialer = redplex.NewSentinelDialer(*remoteNetwork, *sentinels, *sentinelMaster, *dialTimeout)
 	} else {
-		dialer = dialSingle
+		dialer = redplex.NewDirectDialer(*remoteNetwork, *remote, *dialTimeout)
 	}
 
 	closed := make(chan struct{})
@@ -87,27 +86,4 @@ func awaitInterrupt() {
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, syscall.SIGINT)
 	<-interrupt
-}
-
-func dialSingle() (net.Conn, error) { return dialToAddress(*remote) }
-
-func dialToAddress(addr string) (net.Conn, error) {
-	return net.DialTimeout("tcp", addr, *dialTimeout)
-}
-
-func dialSentinel() (net.Conn, error) {
-	snt := &sentinel.Sentinel{
-		Addrs:      *sentinels,
-		MasterName: *sentinelMaster,
-		Dial: func(addr string) (redis.Conn, error) {
-			return redis.Dial("tcp", addr, redis.DialConnectTimeout(*dialTimeout))
-		},
-	}
-
-	master, err := snt.MasterAddr()
-	if err != nil {
-		return nil, err
-	}
-
-	return dialToAddress(master)
 }

--- a/dialer.go
+++ b/dialer.go
@@ -1,0 +1,245 @@
+package redplex
+
+import (
+	"net"
+	"time"
+
+	"fmt"
+
+	"github.com/cenkalti/backoff"
+	"github.com/garyburd/redigo/redis"
+	"github.com/sirupsen/logrus"
+)
+
+// The Dialer is a type that can create a TCP connection to the Redis server.
+type Dialer interface {
+	// Dial attempts to create a connection to the server.
+	Dial() (net.Conn, error)
+}
+
+// defaultTimeout is used in the DirectDialer
+// if a non-zero timeout is not provided.
+const defaultTimeout = time.Second * 5
+
+// DirectDialer creates a direct connection to a single Redis server or IP.
+type DirectDialer struct {
+	network string
+	address string
+	timeout time.Duration
+}
+
+// NewDirectDialer creates a DirectDialer that dials to the given address.
+// If the timeout is 0, a default value of 5 seconds will be used.
+func NewDirectDialer(network string, address string, timeout time.Duration) DirectDialer {
+	if timeout == 0 {
+		timeout = defaultTimeout
+	}
+
+	return DirectDialer{network, address, timeout}
+}
+
+// Dial implements Dialer.Dial
+func (d DirectDialer) Dial() (net.Conn, error) {
+	return net.DialTimeout(d.network, d.address, d.timeout)
+}
+
+// The SentinelDialer dials into the Redis cluster master as defined by
+// the assortment of sentinel servers.
+type SentinelDialer struct {
+	network    string
+	sentinels  []string
+	masterName string
+	timeout    time.Duration
+	closer     chan<- struct{}
+}
+
+// NewSentinelDialer creates a SentinelDialer.
+func NewSentinelDialer(network string, sentinels []string, masterName string, timeout time.Duration) *SentinelDialer {
+	if timeout == 0 {
+		timeout = defaultTimeout
+	}
+
+	return &SentinelDialer{
+		network:    network,
+		sentinels:  sentinels,
+		masterName: masterName,
+		timeout:    timeout,
+		closer:     make(chan struct{}),
+	}
+}
+
+var _ Dialer = &SentinelDialer{}
+
+// Dial implements Dialer.Dial. It looks up and connects to the Redis master
+// dictated by the sentinels. The connection will be closed if we detect
+// that the master changes.
+func (s *SentinelDialer) Dial() (net.Conn, error) {
+	close(s.closer)
+	closer := make(chan struct{})
+	s.closer = closer
+
+	master, err := s.getMaster()
+	if err != nil {
+		return nil, err
+	}
+
+	cnx, err := DirectDialer{s.network, master, s.timeout}.Dial()
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Debugf("redplex/dialer: created connection to %s as the sentinel master", master)
+
+	go s.monitorMaster(cnx, master, closer)
+
+	return cnx, nil
+}
+
+// monitorMaster subscribes to the Sentinel cluster and watches for master
+// changes. When a change happens, it closes the old connection. Often a
+// failover-triggering event will result in the connection being terminated
+// anyway, but this is not always the case--the Sentinels can decide to trigger
+// a failover if load is too high on one server, for instance, even though the
+// server is generally healthy and the connection will remain alive.
+func (s *SentinelDialer) monitorMaster(cnx net.Conn, currentMaster string, closer <-chan struct{}) {
+	backoff := backoff.NewExponentialBackOff()
+	backoff.MaxInterval = time.Second * 10
+
+	defer func() {
+		cnx.Close()
+		logrus.Infof("redplex/dialer: failed over from %s as it is no longer the cluster master", currentMaster)
+	}()
+
+	for {
+		err := s.watchForReelection(backoff, currentMaster, closer)
+		if err == nil {
+			return
+		}
+
+		logrus.WithError(err).Info("redplex/dialer: error connecting to Redis sentinels")
+		select {
+		case <-time.After(backoff.NextBackOff()):
+			continue
+		case <-closer:
+			return
+		}
+	}
+}
+
+// watchForReelection returns a channel which is closed to when the sentinel
+// master changes. Blocks until the subscription is set up. Returns a connection
+// which should be closed when we're no longer interested in it. Resets the
+// backoff once a connection is established successfully.
+func (s *SentinelDialer) watchForReelection(backoff backoff.BackOff, currentMaster string, closer <-chan struct{}) (err error) {
+	for {
+		// First off, subscribe to master changes.
+		psc, err := s.subscribeToElections()
+		if err != nil {
+			return err
+		}
+
+		// Validate the master is current after we set up the pubsub conn
+		// to avoid races.
+		if master, err := s.getMaster(); err != nil || master != currentMaster {
+			psc.Close()
+			return err
+		}
+
+		recvd := make(chan struct{})
+		go func() {
+			select {
+			case <-closer:
+				psc.Close()
+			case <-recvd:
+			}
+		}()
+
+		// Wait until we get a message on the pubsub channel. Once we do and
+		// if it's a subscription message, return.
+		backoff.Reset()
+		_, didReelect := psc.Receive().(redis.Message)
+		close(recvd)
+		psc.Close()
+
+		if didReelect {
+			return nil
+		}
+
+		// Otherwise, loop through if we didn't close intentionally.. Occasional
+		// crashes and timeouts are expected. If we can't connect to anyone
+		// else, the next loop iteration will return an error.
+		select {
+		case <-closer:
+			return nil
+		default:
+		}
+	}
+}
+
+// getMaster returns the current cluster master.
+func (s *SentinelDialer) getMaster() (string, error) {
+	result, err := s.doUntilSuccess(func(conn redis.Conn) (interface{}, error) {
+		res, err := redis.Strings(conn.Do("SENTINEL", "get-master-addr-by-name", s.masterName))
+		if err != nil {
+			return "", err
+		}
+
+		conn.Close()
+		return net.JoinHostPort(res[0], res[1]), nil
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	return result.(string), nil
+}
+
+// subscribeToElections returns a pubsub channel subscribed on a Redis sentinel
+// to cluster master changes.
+func (s *SentinelDialer) subscribeToElections() (redis.PubSubConn, error) {
+	result, err := s.doUntilSuccess(func(conn redis.Conn) (interface{}, error) {
+		psc := redis.PubSubConn{Conn: conn}
+		if err := psc.Subscribe("+switch-master"); err != nil {
+			return psc, err
+		}
+
+		msg := psc.Receive()
+		if _, ok := msg.(redis.Subscription); !ok {
+			return psc, fmt.Errorf("redplex/dialer: expected subscription ack from sentinel, got: %+v", msg)
+		}
+
+		return psc, nil
+	})
+
+	if err != nil {
+		return redis.PubSubConn{}, err
+	}
+
+	return result.(redis.PubSubConn), nil
+}
+
+// doUntilSuccess runs the querying function against sentinels until one
+// returns with a success. If no sentinels respond successfully, the last
+// returned error is bubbled. The connection used in a successful reply will
+// remain open.
+func (s *SentinelDialer) doUntilSuccess(fn func(conn redis.Conn) (interface{}, error)) (result interface{}, err error) {
+	var cnx redis.Conn
+
+	for _, addr := range s.sentinels {
+		cnx, err = redis.Dial(s.network, addr, redis.DialConnectTimeout(s.timeout))
+		if err != nil {
+			continue
+		}
+
+		result, err = fn(cnx)
+		if err != nil {
+			cnx.Close()
+			continue
+		}
+
+		return result, nil
+	}
+
+	return nil, err
+}

--- a/pubsub.go
+++ b/pubsub.go
@@ -105,7 +105,7 @@ func (l listenerMap) removeAll(conn Writable) (toUnsub [][]byte) {
 
 // Pubsub manages the connection of redplex to the remote pubsub server.
 type Pubsub struct {
-	dial         Dialer
+	dialer       Dialer
 	closer       chan struct{}
 	writeTimeout time.Duration
 
@@ -118,7 +118,7 @@ type Pubsub struct {
 // NewPubsub creates a new Pubsub instance.
 func NewPubsub(dialer Dialer, writeTimeout time.Duration) *Pubsub {
 	return &Pubsub{
-		dial:         dialer,
+		dialer:       dialer,
 		writeTimeout: writeTimeout,
 		patterns:     listenerMap{},
 		channels:     listenerMap{},
@@ -132,7 +132,7 @@ func (p *Pubsub) Start() {
 	backoff.MaxInterval = time.Second * 10
 
 	for {
-		cnx, err := p.dial()
+		cnx, err := p.dialer.Dial()
 		if err != nil {
 			logrus.WithError(err).Info("redplex/pubsub: error dialing to pubsub master")
 			select {
@@ -232,7 +232,7 @@ func (p *Pubsub) UnsubscribeAll(c Writable) {
 	p.mu.Unlock()
 }
 
-// command sends the request to the pubsub server asynchonrously.
+// command sends the request to the pubsub server asynchronously.
 func (p *Pubsub) command(r *Request) {
 	if p.connection != nil {
 		p.connection.SetWriteDeadline(time.Now().Add(p.writeTimeout))

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -1,14 +1,11 @@
 package redplex
 
 import (
-	"testing"
-
-	"net"
-	"time"
-
-	"sync"
-
 	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -108,7 +105,7 @@ func (p *PubsubSuite) SetupSuite() {
 
 func (p *PubsubSuite) SetupTest() {
 	p.pubsub = NewPubsub(
-		func() (net.Conn, error) { return net.Dial("tcp", p.server.Addr().String()) },
+		NewDirectDialer("tcp", p.server.Addr().String(), 0),
 		time.Second,
 	)
 

--- a/server.go
+++ b/server.go
@@ -13,10 +13,6 @@ import (
 // buffer on the outgoing connection.
 const toSendQueueLimit = 128
 
-// Dialer is passed into redplex. Calling it should create a new connection to
-// the pubsub master.
-type Dialer func() (net.Conn, error)
-
 // Server is the redplex server which accepts connections and talks to the
 // underlying Pubsub implementation.
 type Server struct {

--- a/server_test.go
+++ b/server_test.go
@@ -28,7 +28,7 @@ func (e *EndToEndServerSuite) SetupSuite() {
 	require.Nil(e.T(), err)
 
 	e.server = NewServer(listener, NewPubsub(
-		func() (net.Conn, error) { return net.Dial("tcp", redisAddress) },
+		NewDirectDialer("tcp", redisAddress, 0),
 		time.Second*5,
 	))
 	go e.server.Listen()

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,12 +3,6 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "Ba9moJKp0ssS+S7v2Zhl0zVmV6U=",
-			"path": "github.com/FZambia/go-sentinel",
-			"revision": "7ec87ec3f92e789de83d4d4a17a5cd069bd2882f",
-			"revisionTime": "2017-09-08T19:10:20Z"
-		},
-		{
 			"checksumSHA1": "KmjnydoAbofMieIWm+it5OWERaM=",
 			"path": "github.com/alecthomas/template",
 			"revision": "a0175ee3bccc567396460bf5acd36800cb10c49c",


### PR DESCRIPTION
This uses our own small Sentinel dialer which subscribes to changes in the cluster master and closes the network connection when a failover occurs. This is what a failover looks like:

```
DEBU[0000] redplex/main: listening on tcp://127.0.0.1:3000
DEBU[0000] redplex/dialer: created connection to 127.0.0.1:6382 as the sentinel master
INFO[0104] redplex/dialer: failed over from 127.0.0.1:6382 as it is no longer the cluster master
INFO[0104] redplex/pubsub: lost connection to pubsub server  error="read tcp 127.0.0.1:57630->127.0.0.1:6382: use of closed network connection"
DEBU[0104] redplex/dialer: created connection to 127.0.0.1:6380 as the sentinel master
```

Previously, the connection would have been kept alive, but pubsub would just stop working. This happened during a soft failover on our cluster a few weeks ago.